### PR TITLE
Fix: Correct baseurl and add placeholder for about page

### DIFF
--- a/portfolio/config.toml
+++ b/portfolio/config.toml
@@ -1,4 +1,5 @@
-baseurl      = "localhost"
+# TODO: Replace with the actual domain name when deploying
+baseurl      = "https://example.com"
 title        = "Arnavdeep's portfolio"
 languageCode = "en-us"
 theme        = "hello-friend-ng"

--- a/portfolio/content/about/about.md
+++ b/portfolio/content/about/about.md
@@ -1,1 +1,7 @@
+---
+title: "About Me"
+date: 2025-05-24T08:00:49+0000
+draft: false
+---
 
+This page is currently under construction. Please check back later!


### PR DESCRIPTION
- I updated `baseurl` in `config.toml` from "localhost" to "https://example.com" and added a TODO comment to remind you to change it to the actual domain during deployment. This fixes an issue where generated links would be incorrect on a deployed site.
- I added placeholder content to `portfolio/content/about/about.md`. The page was previously empty and would have rendered as a blank page. It now indicates that the content is under construction.
- I reviewed social and menu links; no issues found.